### PR TITLE
fix: JudgePort Function 

### DIFF
--- a/pkg/server/controller/handler.go
+++ b/pkg/server/controller/handler.go
@@ -115,6 +115,10 @@ func (c *HandleController) JudgePort(content *plugin.NewProxyContent) plugin.Res
 							break
 						}
 					} else {
+						if str == "" {
+							portAllowed = true
+							break
+						}
 						allowed, err := strconv.Atoi(str)
 						if err != nil {
 							portErr = fmt.Errorf("user [%v] allowed port [%v] is not a number", user, port)
@@ -148,10 +152,14 @@ func (c *HandleController) JudgePort(content *plugin.NewProxyContent) plugin.Res
 	if proxyType == "http" || proxyType == "https" || proxyType == "tcpmux" {
 		if portAllowed {
 			if token, exist := c.Tokens[user]; exist {
-				for _, userDomain := range userDomains {
-					if stringContains(userDomain, token.Domains) {
-						domainAllowed = false
-						break
+				if stringContains("", token.Domains) {
+					domainAllowed = true
+				} else {
+					for _, userDomain := range userDomains {
+						if !stringContains(userDomain, token.Domains) {
+							domainAllowed = false
+							break
+						}
 					}
 				}
 			}
@@ -167,10 +175,14 @@ func (c *HandleController) JudgePort(content *plugin.NewProxyContent) plugin.Res
 		subdomainAllowed = false
 		if portAllowed && domainAllowed {
 			if token, exist := c.Tokens[user]; exist {
-				for _, subdomain := range token.Subdomains {
-					if subdomain == userSubdomain {
-						subdomainAllowed = true
-						break
+				if stringContains("", token.Subdomains) {
+					subdomainAllowed = true
+				} else {
+					for _, subdomain := range token.Subdomains {
+						if subdomain == userSubdomain {
+							subdomainAllowed = true
+							break
+						}
 					}
 				}
 			} else {

--- a/pkg/server/controller/handler.go
+++ b/pkg/server/controller/handler.go
@@ -77,7 +77,7 @@ func (c *HandleController) JudgePort(content *plugin.NewProxyContent) plugin.Res
 		"tcp", "tcpmux", "udp", "http", "https",
 	}
 	proxyType := content.ProxyType
-	if stringContains(proxyType, supportProxyTypes) {
+	if !stringContains(proxyType, supportProxyTypes) {
 		log.Printf("proxy type [%v] not support, plugin do nothing", proxyType)
 		res.Unchange = true
 		return res


### PR DESCRIPTION
fix https://github.com/yhl452493373/frps-panel/issues/8
1、修复在handle.JudgePort 方法中，supportProxyTypes判断错误
2、修复配置文件ports = [""]时表示允许所有端口，但在代码中会进行strconv.Atoi(str)，转化失败，导致错误判断
3、修复在handle.JudgePort 方法中，domainAllowed判断错误
4、修复在handle.JudgePort 方法中，subdomainAllowed判断错误